### PR TITLE
Multi Host Writing & Fields for ES indexing

### DIFF
--- a/logspoutloges.go
+++ b/logspoutloges.go
@@ -76,7 +76,7 @@ func (a *LogesAdapter) Stream(logstream chan *router.Message) {
 
 		idx := "logstash-" + m.Time.Format("2006.01.02")
 		//Index(index string, _type string, id,         ttl string, date *time.Time, data interface{}, refresh bool)
-		if err := a.indexer.Index(idx, "logs", "", "30d", &m.Time, js, false); err != nil {
+		if err := a.indexer.Index(idx, "logs", "", "", "30d", &m.Time, js); err != nil {
 			log.Errorf("Index(ing) error: %v\n", err)
 		}
 	}
@@ -91,9 +91,9 @@ type LogesMessage struct {
 	Tags        []string               `json:"@tags,omitempty"`
 	IndexFields map[string]interface{} `json:"@idx,omitempty"`
 	Fields      map[string]interface{} `json:"@fields"`
-	Name        string                 `json:"docker.name"`
-	ID          string                 `json:"docker.id"`
-	Image       string                 `json:"docker.image"`
-	Hostname    string                 `json:"docker.hostname"`
-	LID         int                    `json:"logspoutloges.id"`
+	Name        string                 `json:"docker-name"`
+	ID          string                 `json:"docker-id"`
+	Image       string                 `json:"docker-image"`
+	Hostname    string                 `json:"docker-hostname"`
+	LID         int                    `json:"logspoutloges-id"`
 }

--- a/logspoutloges.go
+++ b/logspoutloges.go
@@ -15,6 +15,7 @@ var elastigoConn *elastigo.Conn
 
 func init() {
 	router.AdapterFactories.Register(NewLogesAdapter, "logspoutloges")
+	elastigoConn = elastigo.NewConn()
 }
 
 // LogesAdapter is an adapter that streams TCP JSON to Elasticsearch

--- a/logspoutloges.go
+++ b/logspoutloges.go
@@ -70,7 +70,7 @@ func (a *LogesAdapter) Stream(logstream chan *router.Message) {
 		}
 		js, err := json.Marshal(msg)
 		if err != nil {
-			log.Println("loges:", err)
+			log.Errorf("loges marshal error: %v", err)
 			continue
 		}
 

--- a/logspoutloges_test.go
+++ b/logspoutloges_test.go
@@ -1,0 +1,31 @@
+package logspoutloges
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestESAddrs(t *testing.T) {
+	eg := "logspoutloges://10.240.0.1+10.240.0.2+10.240.0.3:9200"
+	egUrl, err := url.Parse(eg)
+	if err != nil {
+		t.Errorf("error parsing %s: %v", eg, err)
+	}
+
+	esHosts := parseEsAddr(egUrl.Host)
+	if len(esHosts) != 3 {
+		t.Errorf("error parsing multi-host route URI: %#v", esHosts)
+	}
+}
+func TestESAddr(t *testing.T) {
+	eg := "logspoutloges://10.240.0.1"
+	egUrl, err := url.Parse(eg)
+	if err != nil {
+		t.Errorf("error parsing %s: %v", eg, err)
+	}
+
+	esHosts := parseEsAddr(egUrl.Host)
+	if len(esHosts) != 1 {
+		t.Errorf("error parsing single-host route URI: %#v", esHosts)
+	}
+}

--- a/logspoutloges_test.go
+++ b/logspoutloges_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+var rawMsg = `{"level":"error","message":"Number of values doesn't match number of fields:  fields:5 vals:6","severity":"ERROR","time":"2017-05-10T20:19:55Z"}`
+var rawMsg2 = `{"level":"error","file":"foo.go","line":20,"message":"Number of values doesn't match number of fields:  fields:5 vals:6","severity":"ERROR","time":"2017-05-10T20:19:55Z"}`
+
 func TestESAddrs(t *testing.T) {
 	eg := "logspoutloges://10.240.0.1+10.240.0.2+10.240.0.3:9200"
 	egUrl, err := url.Parse(eg)
@@ -17,6 +20,7 @@ func TestESAddrs(t *testing.T) {
 		t.Errorf("error parsing multi-host route URI: %#v", esHosts)
 	}
 }
+
 func TestESAddr(t *testing.T) {
 	eg := "logspoutloges://10.240.0.1"
 	egUrl, err := url.Parse(eg)
@@ -27,5 +31,33 @@ func TestESAddr(t *testing.T) {
 	esHosts := parseEsAddr(egUrl.Host)
 	if len(esHosts) != 1 {
 		t.Errorf("error parsing single-host route URI: %#v", esHosts)
+	}
+}
+
+func TestLogFieldUnmarshal(t *testing.T) {
+	lf, err := parseFields([]byte(rawMsg))
+	if err != nil {
+		t.Errorf("error parsing fields: %v", err)
+	}
+	t.Logf("LogFields: %#v", *lf)
+	if lf.Level != "error" {
+		t.Errorf("'level' field not expected 'error' value: %v", lf.Level)
+	}
+}
+
+func TestLogFieldUnmarshalFileLine(t *testing.T) {
+	lf, err := parseFields([]byte(rawMsg2))
+	if err != nil {
+		t.Errorf("error parsing fields: %v", err)
+	}
+	t.Logf("LogFields: %#v", *lf)
+	if lf.Level != "error" {
+		t.Errorf("'level' field not expected 'error' value: %v", lf.Level)
+	}
+	if lf.Line != 20 {
+		t.Errorf("error parsing line number: %v not equal to 20", lf.Line)
+	}
+	if lf.File != "foo.go" {
+		t.Errorf("error parsing file name: %v", lf.File)
 	}
 }


### PR DESCRIPTION
To match our Elasticsaerch log mappings, rewriting previously written docker.X fields to Fields.X so they can be indexed and searched on from Kibana.
